### PR TITLE
[ FEATURE ] Adiciona posts em modo rascunho

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -5,7 +5,9 @@ class PostsController < ApplicationController
 
   # GET /posts or /posts.json
   def index
-    @posts = Post.all
+    @posts = Post.where(draft: false).order(created_at: :desc)
+    # Se estiver logado, exibe os drafts do usuário
+    @drafts = Post.where(draft: true).order(created_at: :desc)
   end
 
   # GET /posts/1 or /posts/1.json
@@ -71,6 +73,6 @@ class PostsController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def post_params
-      params.require(:post).permit(:title, :content, :spotify_track_url)
+      params.require(:post).permit(:title, :content, :spotify_track_url, :draft)
     end
 end

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -21,6 +21,10 @@
     <%= form.text_field :spotify_track_url, class: "rounded-md px-3.5 py-2.5 w-full border border-gray-200" %>
   </div>
 
+  <div class="mt-5 flex gap-1">
+    <%= form.check_box :draft %> <%= form.label :draft, "Rascunho", class: "block font-medium " %>
+  </div>
+
   <div class="mt-5">
     <%= form.label :content, "Conteúdo", class: "block font-medium" %>
     <%= form.rich_text_area :content, class: "rounded-md px-3.5 py-2.5 w-full border border-gray-200" %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -26,4 +26,31 @@
       <p class="text-center my-10">Nenhum post no momento.</p>
     <% end %>
   </div>
+
+<% if authenticated? %>
+  <div class="flex items-center justify-center">
+    <hr class="w-1/3 mx-auto my-10 text-stone-700">
+    <h2>draft</h2>
+    <hr class="w-1/3 mx-auto my-10 text-stone-700">
+  </div>
+  <div id="drafts" class="max-w-fit mx-auto">
+    <% if @drafts.any? %>
+      <% @drafts.each do |draft| %>
+        <div class="w-full flex mx-auto text-2xl mb-10 border-l-8 border-[#ffffff96]">
+          <div class="ml-5 flex flex-col items-start justify-center gap-1 w-full">
+            <%= link_to truncate(draft.title, length: 50), post_path(draft), class: "text-2xl md:text-4xl font-bold hover:font-bolder w-full" %>
+            <div class="flex items-center h-5 gap-0.5"> 
+              <% if draft.user.avatar.attached? %>
+                <%= image_tag draft.user.avatar, class: "rounded-full w-4 sm:w-4" %>
+              <% end %>
+              <span class="text-[#ffff]/60 text-xs"><%= draft.user.name %>,</span>
+              <span class="text-[#ffff]/60 text-xs"><%= time_ago_in_words(draft.created_at) %> atrás</span>
+            </div>
+          </div>
+        </div>
+                   
+      <% end %>
+    <% end %>
+  </div>
+<% end %>
 </div>

--- a/db/migrate/20250327173317_add_draft_to_post.rb
+++ b/db/migrate/20250327173317_add_draft_to_post.rb
@@ -1,0 +1,5 @@
+class AddDraftToPost < ActiveRecord::Migration[8.0]
+  def change
+    add_column :posts, :draft, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_07_031107) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_27_173317) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
     t.text "body"
@@ -57,6 +57,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_07_031107) do
     t.integer "user_id"
     t.string "spotify_track_url"
     t.string "slug"
+    t.boolean "draft", default: true
     t.index ["slug"], name: "index_posts_on_slug", unique: true
     t.index ["user_id"], name: "index_posts_on_user_id"
   end


### PR DESCRIPTION
This pull request introduces a new feature to handle draft posts in the `PostsController`. The changes include modifications to the controller, views, and database schema to support this new functionality.

### Controller Changes:
* Updated the `index` action in `PostsController` to filter out drafts from the main post list and to add a separate list for drafts if the user is logged in.
* Modified the `post_params` method to permit the `draft` parameter, allowing drafts to be created and updated.

### View Changes:
* Added a checkbox for the `draft` attribute in the post form to allow users to mark posts as drafts.
* Updated the `index` view to display drafts separately for authenticated users.

### Database Changes:
* Created a migration to add a `draft` column to the `posts` table, with a default value of `true`.
* Updated the schema file to include the new `draft` column in the `posts` table.