### PR TITLE
[ BUGFIX ] Corrige ausência de espaçamento entre posts

### DIFF
--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -5,10 +5,10 @@
     <p class="mx-auto py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-md inline-block" id="notice"><%= notice %></p>
   <% end %>
 
-  <div id="posts" class="max-w-fit mx-auto gap-4">
+  <div id="posts" class="max-w-fit mx-auto">
     <% if @posts.any? %>
       <% @posts.each do |post| %>
-        <div class="w-full flex mx-auto text-2xl border-l-8 border-[#4a0bae96] post">
+        <div class="w-full flex mx-auto mb-10 text-2xl border-l-8 border-[#4a0bae96] post">
           <div class="ml-5 flex flex-col items-start justify-center gap-1 w-full">
             <%= link_to truncate(post.title, length: 50), post_path(post), class: "text-2xl md:text-4xl font-bold hover:font-bolder w-full" %>
             <div class="flex items-center h-5 gap-0.5"> 
@@ -36,7 +36,7 @@
   <div id="drafts" class="max-w-fit mx-auto">
     <% if @drafts.any? %>
       <% @drafts.each do |draft| %>
-        <div class="w-full flex mx-auto text-2xl mb-10 border-l-8 border-[#ffffff96]">
+        <div class="w-full flex mx-auto text-2xl my-10 border-l-8 border-[#ffffff96]">
           <div class="ml-5 flex flex-col items-start justify-center gap-1 w-full">
             <%= link_to truncate(draft.title, length: 50), post_path(draft), class: "text-2xl md:text-4xl font-bold hover:font-bolder w-full" %>
             <div class="flex items-center h-5 gap-0.5"> 


### PR DESCRIPTION
This pull request includes changes to the layout and spacing of posts and drafts on the index page to improve visual consistency and readability.

Layout and spacing improvements:

* [`app/views/posts/index.html.erb`](diffhunk://#diff-2940ba8acf3ebe1e62655323a9159f954851342b3a0c24f75909c0ea81328a62L8-R11): Removed the `gap-4` class from the `#posts` div to eliminate unnecessary spacing between posts.
* [`app/views/posts/index.html.erb`](diffhunk://#diff-2940ba8acf3ebe1e62655323a9159f954851342b3a0c24f75909c0ea81328a62L8-R11): Added `mb-10` class to the post div to provide consistent bottom margin for each post.
* [`app/views/posts/index.html.erb`](diffhunk://#diff-2940ba8acf3ebe1e62655323a9159f954851342b3a0c24f75909c0ea81328a62L39-R39): Changed the margin class from `mb-10` to `my-10` for the draft div to ensure consistent vertical spacing around each draft.